### PR TITLE
fix: fix optimism auto-wrap subgraph config

### DIFF
--- a/.github/workflows/aw-subgraph-ci-goldsky.yml
+++ b/.github/workflows/aw-subgraph-ci-goldsky.yml
@@ -2,6 +2,23 @@ name: Deploy WrapScheduler Subgraphs (Goldsky)
 
 on:
   workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network to deploy (select "all" for all networks)'
+        required: true
+        type: choice
+        options:
+          - all
+          - avalanche-c
+          - arbitrum-one
+          - bsc-mainnet
+          - eth-mainnet
+          - xdai-mainnet
+          - optimism-mainnet
+          - polygon-mainnet
+          - optimism-sepolia
+          - base-mainnet
+        default: 'all'
   push:
     branches:
       - "release-v1/*"
@@ -17,18 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        networks:
-          [
-            "avalanche-c",
-            "arbitrum-one",
-            "bsc-mainnet",
-            "eth-mainnet",
-            "xdai-mainnet",
-            "optimism-mainnet",
-            "polygon-mainnet",
-            "optimism-sepolia",
-            "base-mainnet"
-          ]
+        networks: ${{ github.event.inputs.network == 'all' && fromJson('["avalanche-c", "arbitrum-one", "bsc-mainnet", "eth-mainnet", "xdai-mainnet", "optimism-mainnet", "polygon-mainnet", "optimism-sepolia", "base-mainnet"]') || fromJson(format('["{0}"]', github.event.inputs.network)) }}
     steps:
       - uses: actions/checkout@v4
       - name: Install node

--- a/subgraphs/wrap-scheduler/config/optimism-mainnet.json
+++ b/subgraphs/wrap-scheduler/config/optimism-mainnet.json
@@ -1,5 +1,5 @@
 {
   "network": "optimism",
-  "wrapManagerAddress": "0xe567b32C10B0dB72d9490eB1B9A409C5ADed192C",
-  "wrapManagerStartBlock": 11311085
+  "wrapManagerAddress": "0x1fA76f2Cd0C3fe6c399A80111408d9C42C0CAC23",
+  "wrapManagerStartBlock": 91580804
 }


### PR DESCRIPTION
Previously wrong address and block number were specified. Additionally, allow deploying to a single network in the GitHub workflow.